### PR TITLE
rpearce: Fixing support for Debian/Ubuntu.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,12 +50,13 @@ class squid3 (
   service { $service_name:
     enable    => true,
     ensure    => running,
-    restart   => "/sbin/service ${service_name} reload",
+    restart   => "service ${service_name} reload",
+    path      => ['/sbin', '/usr/sbin'],
     hasstatus => true,
     require   => Package[$package_name],
   }
 
-  file { '/etc/squid/squid.conf':
+  file { $config_file:
     require => Package[$package_name],
     notify  => Service[$service_name],
     content => template('squid3/squid.conf.erb'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,14 +10,17 @@ class squid3::params {
         $package_name = 'squid'
       }
       $service_name = 'squid'
+      $config_file = '/etc/squid/squid.conf'
     }
     'Debian': {
-      $default_package_name = 'squid'
+      $package_name = 'squid3'
       $service_name = 'squid3'
+      $config_file = '/etc/squid3/squid.conf'
     }
     default: {
-      $default_package_name = 'squid'
+      $package_name = 'squid'
       $service_name = 'squid'
+      $config_file = '/etc/squid/squid.conf'
     }
   }
 


### PR DESCRIPTION
Bug fixed in params.pp s/default_package_name/package_name/
Corrected package name for Debian/Ubuntu (squid3)
Added a config_file param due to support Debian/Ubuntu (/etc/squid3/squid.conf)
Added path to service to support Debian/Ubuntu (/usr/sbin/service)
