### PR TITLE
Fix coredump_dir default.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,23 +12,24 @@ class squid3::params {
       $service_name = 'squid'
       $config_file = '/etc/squid/squid.conf'
       $log_directory = '/var/log/squid'
+      $coredump_dir  = '/var/spool/squid'
     }
-    'Debian': {
+    'Debian', 'Ubuntu': {
       $package_name  = 'squid3'
       $service_name  = 'squid3'
       $config_file   = '/etc/squid3/squid.conf'
       $log_directory = '/var/log/squid3'
+      $coredump_dir  = '/var/spool/squid3'
     }
     default: {
       $package_name = 'squid'
       $service_name = 'squid'
       $config_file = '/etc/squid/squid.conf'
       $log_directory = '/var/log/squid'
+      $coredump_dir  = '/var/spool/squid'
     }
   }
   $access_log      = [ "${log_directory}/access.log squid" ]
   $cache_log       = "${log_directory}/cache.log"
   $cache_store_log = "${log_directory}/store.log"
-
 }
-

--- a/templates/squid.conf.erb
+++ b/templates/squid.conf.erb
@@ -2624,7 +2624,7 @@ cache_log <%= @cache_log %>
 #
 
 # Leave coredumps in the first cache dir
-coredump_dir /var/spool/squid
+coredump_dir <%= @coredump_dir %>
 
 # OPTIONS FOR FTP GATEWAYING
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Debian and Ubuntu both use /var/spool/squid3 as opposed to /var/spool/squid.  This generates
an error during startup and results in core dumps being dropped in / instead.
