### PR TITLE
Fix upstart error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+---
+branches:
+  only:
+    - master
+language: ruby
+before_install:
+  - gem update bundler
+  - bundle --version
+  - gem update --system 2.1.11
+  - gem --version
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.7.2"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,25 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+group :development, :test do
+  gem 'rake',                    :require => false
+  gem 'rspec-puppet',            :require => false
+  gem 'puppetlabs_spec_helper',  :require => false
+  gem 'serverspec',              :require => false
+  gem 'puppet-lint',             :require => false
+  gem 'beaker',                  :require => false
+  gem 'beaker-rspec',            :require => false
+  gem 'pry',                     :require => false
+  gem 'simplecov',               :require => false
+end
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end

--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ class { '::squid3':
 }
 ```
 
+## Caveats
+
+Upgrading Squid3 from version 3.2 to 3.3 breaks the configuration file to fix :
+
+```puppet
+class { '::squid3':
+  use_deprecated_opts => false
+}
+```
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class squid3 (
   $config_hash                   = {},
   $refresh_patterns              = [],
   $template                      = 'long',
+  $version                       = 'installed'
 ) inherits ::squid3::params {
 
   $use_template = $template ? {
@@ -57,7 +58,7 @@ class squid3 (
   }
 
 
-  package { 'squid3_package': ensure => installed, name => $package_name }
+  package { 'squid3_package': ensure => $version, name => $package_name }
 
   service { 'squid3_service':
     enable    => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@
 #
 class squid3 (
   # Options are in the same order they appear in squid.conf
+  $use_deprecated_opts  = true,
   $http_port            = [ '3128' ],
   $acl                  = [],
   $http_access          = [],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@ class squid3 (
   package { 'squid3_package': ensure => $version, name => $package_name }
 
   service { 'squid3_service':
-    enable    => true,
+    enable    => $service_enable,
     name      => $service_name,
     ensure    => running,
     restart   => "service ${service_name} reload",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class squid3 (
   # Options are in the same order they appear in squid.conf
   $use_deprecated_opts  = true,
   $http_port            = [ '3128' ],
+  $https_port           = [],
   $acl                  = [],
   $http_access          = [],
   $icp_access           = [],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,24 +9,26 @@ class squid3::params {
       } else {
         $package_name = 'squid'
       }
-      $service_name  = 'squid'
-      $config_file   = '/etc/squid/squid.conf'
-      $log_directory = '/var/log/squid'
-      $coredump_dir  = '/var/spool/squid'
+      $service_name   = 'squid'
+      $service_enable = true
+      $config_file    = '/etc/squid/squid.conf'
+      $log_directory  = '/var/log/squid'
+      $coredump_dir   = '/var/spool/squid'
     }
     'Debian', 'Ubuntu': {
-      $package_name  = 'squid3'
-      $service_name  = 'squid3'
-      $config_file   = '/etc/squid3/squid.conf'
-      $log_directory = '/var/log/squid3'
-      $coredump_dir  = '/var/spool/squid3'
+      $package_name   = 'squid3'
+      $service_name   = 'squid3'
+      $service_enable = false
+      $config_file    = '/etc/squid3/squid.conf'
+      $log_directory  = '/var/log/squid3'
+      $coredump_dir   = '/var/spool/squid3'
     }
     default: {
-      $package_name  = 'squid'
-      $service_name  = 'squid'
-      $config_file   = '/etc/squid/squid.conf'
-      $log_directory = '/var/log/squid'
-      $coredump_dir  = '/var/spool/squid'
+      $package_name   = 'squid'
+      $service_name   = 'squid'
+      $config_file    = '/etc/squid/squid.conf'
+      $log_directory  = '/var/log/squid'
+      $coredump_dir   = '/var/spool/squid'
     }
   }
 

--- a/spec/classes/squid3_spec.rb
+++ b/spec/classes/squid3_spec.rb
@@ -92,24 +92,28 @@ describe 'squid3' do
     context 'Ubuntu - long template - with https_port support' do
       let(:facts) {{ :osfamily => 'Debian'}}
       let(:params) {{
-          :template => 'long',
-          :https_port => ['443']
+          :template   => 'long',
+          :https_port => ['443'],
+          :http_port  => []
       }}
 
       it "set https_port with a valid port" do
         should contain_file('/etc/squid3/squid.conf').with_content(/^https_port +443$/)
+        should contain_file('/etc/squid3/squid.conf').without_content(/^http_port.*$/)
       end
     end
 
     context 'Ubuntu - short template - with https_port support' do
       let(:facts) {{ :osfamily => 'Debian'}}
       let(:params) {{
-          :template => 'short',
-          :https_port => ['443']
+          :template   => 'short',
+          :https_port => ['443'],
+          :http_port  => []
       }}
 
       it "set https_port with a valid port" do
         should contain_file('/etc/squid3/squid.conf').with_content(/^https_port +443$/)
+        should contain_file('/etc/squid3/squid.conf').without_content(/^http_port.*$/)
       end
     end
 

--- a/spec/classes/squid3_spec.rb
+++ b/spec/classes/squid3_spec.rb
@@ -117,4 +117,26 @@ describe 'squid3' do
       end
     end
 
+    context 'Ubuntu - with upstart support' do
+      let(:facts) {{ :osfamily => 'Debian'}}
+      let(:params) {{
+          :template   => 'short',
+      }}
+
+      it "it should not enable the service" do
+        should contain_service('squid3_service').with('enable' => false)
+      end
+    end
+
+    context 'RedHat - with SysV init support' do
+      let(:facts) { facts_hash }
+      let(:params){{
+          :template => 'short'
+      }}
+
+      it "it should enable the service" do
+        should contain_service('squid3_service').with('enable' => true)
+      end
+    end
+
 end

--- a/spec/classes/squid3_spec.rb
+++ b/spec/classes/squid3_spec.rb
@@ -21,6 +21,7 @@ describe 'squid3' do
 
         it "should have long config file" do
           should contain_file('/etc/squid/squid.conf').with_content( /This is the default Squid configuration file/ )
+          should contain_file('/etc/squid/squid.conf').with_content( /acl manager proto cache_object/ )
         end
     end
 
@@ -32,6 +33,7 @@ describe 'squid3' do
 
         it "should have short config file" do
           should contain_file('/etc/squid/squid.conf').with_content( /MANAGED BY PUPPET/ )
+          should contain_file('/etc/squid/squid.conf').with_content( /acl manager proto cache_object/ )
         end
     end
 
@@ -57,6 +59,34 @@ describe 'squid3' do
         it "should have the proper config entries" do
           should contain_file('/etc/squid/squid.conf').with_content(/^whoops +boops$/)
         end
+    end
+
+    context 'Ubuntu - long template - with post 3.2 options deprecated' do
+      let(:facts) {{ :osfamily => 'Debian'}}
+      let(:params) {{
+        :template => 'long',
+        :use_deprecated_opts => false
+      }}
+
+      it "should remove deprecated entries" do
+        should contain_file('/etc/squid3/squid.conf').without_content(/^acl manager proto cache_object$/)
+        should contain_file('/etc/squid3/squid.conf').without_content(/^acl localhost src 127.0.0.1\/32 ::1$/)
+        should contain_file('/etc/squid3/squid.conf').without_content(/^acl to_localhost dst 127.0.0.0\/8 0.0.0.0\/32 ::1$/)
+      end
+    end
+
+    context 'Ubuntu - short template - with post 3.2 options deprecated' do
+      let(:facts) {{ :osfamily => 'Debian'}}
+      let(:params) {{
+          :template => 'short',
+          :use_deprecated_opts => false
+      }}
+
+      it "should remove deprecated entries" do
+        should contain_file('/etc/squid3/squid.conf').without_content(/^acl manager proto cache_object$/)
+        should contain_file('/etc/squid3/squid.conf').without_content(/^acl localhost src 127.0.0.1\/32 ::1$/)
+        should contain_file('/etc/squid3/squid.conf').without_content(/^acl to_localhost dst 127.0.0.0\/8 0.0.0.0\/32 ::1$/)
+      end
     end
 
 end

--- a/spec/classes/squid3_spec.rb
+++ b/spec/classes/squid3_spec.rb
@@ -89,4 +89,28 @@ describe 'squid3' do
       end
     end
 
+    context 'Ubuntu - long template - with https_port support' do
+      let(:facts) {{ :osfamily => 'Debian'}}
+      let(:params) {{
+          :template => 'long',
+          :https_port => ['443']
+      }}
+
+      it "set https_port with a valid port" do
+        should contain_file('/etc/squid3/squid.conf').with_content(/^https_port +443$/)
+      end
+    end
+
+    context 'Ubuntu - short template - with https_port support' do
+      let(:facts) {{ :osfamily => 'Debian'}}
+      let(:params) {{
+          :template => 'short',
+          :https_port => ['443']
+      }}
+
+      it "set https_port with a valid port" do
+        should contain_file('/etc/squid3/squid.conf').with_content(/^https_port +443$/)
+      end
+    end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,10 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 
 RSpec.configure do |c|
 
   # Use color in STDOUT
-  c.color_enabled = true
+  c.color = true
 
   # Use color not only in STDOUT but also in pagers and files
   c.tty = true

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1188,8 +1188,10 @@ http_port <%= line %>
 #
 #Default:
 # none
+<% if @https_port -%>
 <% @https_port.each do |line| -%>
 https_port <%= line %>
+<% end -%>
 <% end -%>
 
 #  TAG: tcp_outgoing_tos

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -639,9 +639,11 @@
 #
 # Recommended minimum configuration:
 #
+<% if @use_deprecated_opts -%>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+<% end -%>
 
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1188,6 +1188,9 @@ http_port <%= line %>
 #
 #Default:
 # none
+<% @https_port.each do |line| -%>
+https_port <%= line %>
+<% end -%>
 
 #  TAG: tcp_outgoing_tos
 #	Allows you to select a TOS/Diffserv value to mark outgoing

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -54,6 +54,11 @@ icp_access <%= line %>
 http_port <%= line %>
 <% end -%>
 
+# user-defined https_port
+<% @https_port.each do |line| -%>
+https_port <%= line %>
+<% end -%>
+
 # user-defined tcp_outgoing_addresses
 <% @tcp_outgoing_address.each do |line| -%>
 tcp_outgoing_address <%= line %>

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -49,14 +49,18 @@ http_access deny all
 icp_access <%= line %>
 <% end -%>
 
+<% if @http_port -%>
 # user-defined http_port
 <% @http_port.each do |line| -%>
 http_port <%= line %>
 <% end -%>
+<% end -%>
 
+<% if @https_port -%>
 # user-defined https_port
 <% @https_port.each do |line| -%>
 https_port <%= line %>
+<% end -%>
 <% end -%>
 
 # user-defined tcp_outgoing_addresses

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -2,9 +2,11 @@
 ## DO NOT EDIT.
 
 # predefined ACLs
+<% if @use_deprecated_opts -%>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+<% end -%>
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network


### PR DESCRIPTION
Fixing upstart error:

==> proxy: Error: Execution of '/usr/sbin/update-rc.d squid3 defaults' returned 1: update-rc.d: /etc/init.d/squid3: file does not exist
==> proxy: Error: /Stage[main]/Squid3/Service[squid3_service]/enable: change from false to true failed: Execution of '/usr/sbin/update-rc.d squid3 defaults' returned 1: update-rc.d: /etc/init.d/squid3: file does not exist