### PR TITLE
Fix to handle new config file format

### DIFF
--- a/lib/facter/squid_version.rb
+++ b/lib/facter/squid_version.rb
@@ -1,0 +1,5 @@
+Facter.add('squid_version') do
+  setcode do
+    Facter::Util::Resolution.exec('/usr/sbin/squid3 -v');
+  end
+end

--- a/lib/facter/squid_version.rb
+++ b/lib/facter/squid_version.rb
@@ -1,5 +1,5 @@
 Facter.add('squid_version') do
   setcode do
-    Facter::Util::Resolution.exec('/usr/sbin/squid3 -v');
+    Facter::Util::Resolution.exec('/usr/sbin/squid3 -v | awk \'/Version/ { print $NF}\'');
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,9 @@ class squid3 (
 ) inherits ::squid3::params {
 
   notify { "squid version: ${squid_version}": }
+  if versioncmp($squid_version, '3.2') < 0) {
+    'old_squid_format' => true
+  }
 
   $use_template = $template ? {
     'short' => 'squid3/squid.conf.short.erb',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class squid3 (
 
   notify { "squid version: ${squid_version}": }
   if versioncmp($squid_version, '3.2') < 0 {
-    'old_squid_format' => true
+    $old_squid_format = true
   }
 
   $use_template = $template ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class squid3 (
 ) inherits ::squid3::params {
 
   notify { "squid version: ${squid_version}": }
-  if versioncmp($squid_version, '3.2') < 0) {
+  if versioncmp($squid_version, '3.2') < 0 {
     'old_squid_format' => true
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,9 +71,7 @@ class squid3 (
     restart   => "service ${service_name} reload",
     path      => ['/sbin', '/usr/sbin'],
     hasstatus => true,
-    if $::osfamily == 'Ubuntu' {
-      provider => 'upstart',
-    }
+    provider  => 'upstart',
     require   => Package['squid3_package'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,9 @@ class squid3 (
     restart   => "service ${service_name} reload",
     path      => ['/sbin', '/usr/sbin'],
     hasstatus => true,
+    if $::osfamily == 'Ubuntu' {
+      provider => 'upstart',
+    }
     require   => Package['squid3_package'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,6 @@ class squid3 (
     restart   => "service ${service_name} reload",
     path      => ['/sbin', '/usr/sbin'],
     hasstatus => true,
-    provider  => upstart,
     require   => Package['squid3_package'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@ class squid3 (
     restart   => "service ${service_name} reload",
     path      => ['/sbin', '/usr/sbin'],
     hasstatus => true,
-    provider  => 'upstart',
+    provider  => upstart,
     require   => Package['squid3_package'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,6 @@ class squid3 (
   $template                      = 'long',
 ) inherits ::squid3::params {
 
-  notify { "squid version: ${squid_version}": }
   if versioncmp($squid_version, '3.2') < 0 {
     $old_squid_format = true
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,8 @@ class squid3 (
   $template                      = 'long',
 ) inherits ::squid3::params {
 
+  notify { "squid version: ${squid_version}": }
+
   $use_template = $template ? {
     'short' => 'squid3/squid.conf.short.erb',
     'long'  => 'squid3/squid.conf.long.erb',

--- a/templates/squid.conf.documented
+++ b/templates/squid.conf.documented
@@ -639,9 +639,11 @@
 #
 # Recommended minimum configuration:
 #
+<% if @old_squid_format %>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+<% end %>
 
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -639,9 +639,11 @@
 #
 # Recommended minimum configuration:
 #
+<% if @old_squid_format %>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+<% end %>
 
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -2,9 +2,11 @@
 ## DO NOT EDIT.
 
 # predefined ACLs
+<% if @old_squid_format %>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+<% end %>
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network


### PR DESCRIPTION
as of 3.2 the ACLs manager, localhost and to_localhost are built-in to squid. Putting those in the config file breaks things terribly.

I've added a custom fact to return installed squid version and wrapped the template config file in a bit of conditional code to only include those lines for versions of squid older than 3.2.