### PR TITLE
Add puppetlabs-stdlib dependency.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,3 +6,4 @@ license 'Apache 2.0'
 summary 'Squid 3 http proxy server module'
 description "Install, enable and configure a Squid 3 http proxy server."
 project_page 'https://github.com/thias/puppet-squid3'
+dependency 'puppetlabs-stdlib', '>= 2.4.0'


### PR DESCRIPTION
'puppet module install thias-squid3' doesn't install puppetlabs-stdlib and hence fail at empty function:
"Unknown function empty at <module_path>/squid3/manifests/init.pp:55"

This PR allows 'puppet module install thias-squid3' to just work out of the box.