### PR TITLE
support for authenticated proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,30 @@ class { '::squid3':
 }
 ```
 
+Password protected proxy (basic authentication):
+```puppet
+  class { "::squid3":
+    template      => "short",
+    auth_required => true,
+    config_hash   => {
+      "auth_param basic program"     => "/usr/lib64/squid/ncsa_auth /etc/squid/squid.passwd",
+      "auth_param basic realm"       => "proxy",
+      "acl authenticated proxy_auth" => "REQUIRED",
+      "http_access allow"            => "authenticated",
+      "http_access deny"             => "all",
+    }
+  }
+
+  file { "/etc/squid/squid.passwd":
+    ensure => file,
+    source => "puppet:///modules/profiles/squid.passwd",
+    owner  => "root",
+    group  => "squid",
+    mode   => "0640",
+    notify => Service["squid"],
+  }
+```
+Here, we have installed the password file we built with `htpasswd` to the squid
+directory and have updated squid to use it with the `ncsa_auth` program (this
+is a centos box).  The `auth_required` attribute disables the rules allowing 
+`localnet` access in squid.conf.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class squid3 (
   $config_hash                   = {},
   $refresh_patterns              = [],
   $template                      = 'long',
+  $auth_required                 = false,
 ) inherits ::squid3::params {
 
   $use_template = $template ? {

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -789,11 +789,13 @@ http_access <%= line %>
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
+<% if not @auth_required -%>
 http_access allow localnet
 http_access allow localhost
 
 # And finally deny all other access to this proxy
 http_access deny all
+<% end %>
 
 #  TAG: adapted_http_access
 #	Allowing or Denying access based on defined access lists

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -38,9 +38,11 @@ acl <%= line %>
 <% @http_access.each do |line| -%>
 http_access <%= line %>
 <% end -%>
+<% if not @auth_required -%>
 http_access allow localnet
 http_access allow localhost
 http_access deny all
+<% end -%>
 
 # user-defined icp_access
 <% @icp_access.each do |line| -%>


### PR DESCRIPTION
Hi Matthias,

I've added simple support and documentation for using your squid module to setup basic authentication with squid and I'm hoping it may be possible to merge this upstream.

This PR works by adding a new boolean variable to the `init.pp` file called `auth_required`.  If this is set, the default access from `localnet` and `localhost` will be disabled.

Users can then supply an additional config hash to setup the program to use for authentication and to copy across the password file to use.  I've included an example of this in the project readme.

Thanks,
Geoff