### PR TITLE
convert config_hash to array to preserve ordering

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,8 @@ class squid3 (
   $server_persistent_connections = 'on',
   $maximum_object_size           = '4096 KB',
   $maximum_object_size_in_memory = '512 KB',
-  $config_hash                   = {},
+  $config_array                  = false,
+  $config_hash                   = false,
   $refresh_patterns              = [],
   $template                      = 'long',
   $package_version               = 'installed',
@@ -38,8 +39,12 @@ class squid3 (
     default => $template,
   }
 
-  if ! empty($config_hash) and $use_template == 'long' {
-    fail('$config_hash does not (yet) work with the "long" template!')
+  if ($config_array or $config_hash) and $use_template == 'long' {
+    fail('config_array and config_hash do not (yet) work with the "long" template!')
+  }
+
+  if $config_array and $config_hash {
+    fail('only one of config_array or config_hash can be used')
   }
 
   package { 'squid3_package':

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -101,6 +101,13 @@ refresh_pattern                .                     0    20%     4320
 
 
 # user-defined configuration settings from config_hash
+<% if @config_hash -%>
 <% @config_hash.sort_by {|k,v| k}.each do |k,v| -%>
 <%= "%*s"%[-30,k] %> <%= v %>
+<% end -%>
+<% end -%>
+<% if @config_array -%>
+<% @config_array.each do |v| -%>
+<%= v %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Converted `config_hash` to be an array as I was getting random ordering in the config file otherwise