### PR TITLE
Fix Evaluation Error: Comparison of: String < Integer, is not possible. ...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class squid3::params {
 
   case $::osfamily {
     'RedHat': {
-      if $::operatingsystemrelease < 6 {
+      if versioncmp($::operatingsystemrelease,'6') < 0 {
         $package_name = 'squid3'
       } else {
         $package_name = 'squid'
@@ -35,4 +35,3 @@ class squid3::params {
   $cache_store_log = "${log_directory}/store.log"
 
 }
-


### PR DESCRIPTION
...Caused by 'A String is not comparable to a non String'.