### PR TITLE
Removing "path" param, causing problems with Ubuntu 14.04.3 LTS's 3.3.8-1ubuntu6.3 pkg

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,6 @@ class squid3 (
     name      => $service_name,
     ensure    => running,
     restart   => "service ${service_name} reload",
-    path      => ['/sbin', '/usr/sbin'],
     hasstatus => true,
     require   => Package['squid3_package'],
   }


### PR DESCRIPTION
…3 package

Was seeing this before:
proxy# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for proxy
Info: Applying configuration version '1444072077'
Error: Execution of '/usr/sbin/update-rc.d squid3 defaults' returned 1: update-rc.d: /etc/init.d/squid3: file does not exist
Error: /Stage[main]/Squid3/Service[squid3_service]/enable: change from false to true failed: Execution of '/usr/sbin/update-rc.d squid3 defaults' returned 1: update-rc.d: /etc/init.d/squid3: file does not exist
Notice: Finished catalog run in 11.45 seconds
proxy#