### PR TITLE
Add validate_cmd to $config_file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,9 +56,10 @@ class squid3 (
   }
 
   file { $config_file:
-    require => Package['squid3_package'],
-    notify  => Service['squid3_service'],
-    content => template($use_template),
+    require      => Package['squid3_package'],
+    notify       => Service['squid3_service'],
+    content      => template($use_template),
+    validate_cmd => "/usr/sbin/${service_name} -k parse -f %",
   }
 
 }


### PR DESCRIPTION
This adds validation so puppet will fail and expose the error if the configuration is incorrect.