### PR TITLE
Update example so it will pass validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Non-caching multi-homed proxy server :
 ```puppet
 class { '::squid3':
   acl => [
-    'de myip 192.168.1.1',
-    'fr myip 192.168.1.2',
+    'country_de myip 192.168.1.1',
+    'country_fr myip 192.168.1.2',
     'office src 10.0.0.0/24',
   ],
   http_access => [


### PR DESCRIPTION
acl name is different that what is used in tcp_outgoing_address, addressessing this so validation will pass when attempting to use the example.