### PR TITLE
Added couple of config parameters and fixed refresh_patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea
 Gemfile.lock
+
+#Geppetto files
+.project

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class squid3 (
   $http_access                   = [],
   $icp_access                    = [],
   $tcp_outgoing_address          = [],
+  $cache_peer                    = [],
   $cache_mem                     = '256 MB',
   $cache_dir                     = [],
   $cache                         = [],
@@ -22,6 +23,8 @@ class squid3 (
   $server_persistent_connections = 'on',
   $maximum_object_size           = '4096 KB',
   $maximum_object_size_in_memory = '512 KB',
+  $memory_replacement_policy     = undef,
+  $cache_replacement_policy      = undef,
   $config_hash                   = {},
   $refresh_patterns              = [],
   $template                      = 'long',
@@ -31,6 +34,9 @@ class squid3 (
   $service_enable                = $::squid3::params::service_enable,
   $service_name                  = $::squid3::params::service_name,
 ) inherits ::squid3::params {
+  validate_re($cache_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
+  validate_re($memory_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
+  validate_array($cache_peer)
 
   $use_template = $template ? {
     'short' => 'squid3/squid.conf.short.erb',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,8 +34,12 @@ class squid3 (
   $service_enable                = $::squid3::params::service_enable,
   $service_name                  = $::squid3::params::service_name,
 ) inherits ::squid3::params {
-  validate_re($cache_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
-  validate_re($memory_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
+  if $cache_replacement_policy != undef {
+    validate_re($cache_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
+  }
+  if $memory_replacement_policy != undef {
+    validate_re($memory_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
+  }
   validate_array($cache_peer)
 
   $use_template = $template ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class squid3 (
     validate_re($memory_replacement_policy, '^(lru|heap GDSF|heap LFUDA|heap LRU)$')
   }
   validate_array($cache_peer)
+  validate_array($refresh_patterns)
 
   $use_template = $template ? {
     'short' => 'squid3/squid.conf.short.erb',

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1796,6 +1796,9 @@ tcp_outgoing_address <%= line %>
 #	
 #Default:
 # none
+<% @cache_peer.each do |line| -%>
+cache_peer <%= line %>
+<% end -%>
 
 #  TAG: cache_peer_domain
 #	Use to limit the domains for which a neighbor cache will be
@@ -1947,6 +1950,9 @@ maximum_object_size_in_memory <%= @maximum_object_size_in_memory %>
 #	See cache_replacement_policy for details.
 #Default:
 # memory_replacement_policy lru
+<% if @memory_replacement_policy -%>
+memory_replacement_policy <%= @memory_replacement_policy %>
+<% end -%>
 
 # DISK CACHE OPTIONS
 # -----------------------------------------------------------------------------
@@ -1987,6 +1993,9 @@ maximum_object_size_in_memory <%= @maximum_object_size_in_memory %>
 #	and http://fog.hpl.external.hp.com/techreports/98/HPL-98-173.html.
 #Default:
 # cache_replacement_policy lru
+<% if @cache_replacement_policy -%>
+cache_replacement_policy <%= @cache_replacement_policy %>
+<% end -%>
 
 #  TAG: cache_dir
 #	Usage:

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -2966,6 +2966,9 @@ cache <%= line %>
 #
 
 # Add any of your own refresh_pattern entries above these.
+<% @refresh_patterns.each do |line| -%>
+refresh_pattern <%= line %>
+<% end -%>
 refresh_pattern ^ftp:		1440	20%	10080
 refresh_pattern ^gopher:	1440	0%	1440
 refresh_pattern -i (/cgi-bin/|\?) 0	0%	0

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -63,6 +63,10 @@ https_port <%= line %>
 tcp_outgoing_address <%= line %>
 <% end -%>
 
+<% @cache_peer.each do |line| -%>
+cache_peer <%= line %>
+<% end -%>
+
 # user-defined cache-dirs
 <% @cache_dir.each do |line| -%>
 cache_dir <%= line %>
@@ -73,6 +77,8 @@ cache_dir <%= line %>
 hierarchy_stoplist             cgi-bin ?
 coredump_dir                   <%= @coredump_dir %>
 maximum_object_size_in_memory  <%= @maximum_object_size_in_memory  %>
+memory_replacement_policy      <%= @memory_replacement_policy      %>
+cache_replacement_policy       <%= @cache_replacement_policy       %>
 maximum_object_size            <%= @maximum_object_size            %>
 ignore_expect_100              <%= @ignore_expect_100              %>
 cache_mgr                      <%= @cache_mgr                      %>


### PR DESCRIPTION
Added the capability to configure 3 more parameters in squid.conf; cache_replacement_policy, memory_replacement_policy and cache peer. Also added refresh_patterns in the long template as the parameter setting code was missing.

I used validators but I noticed that you rely on checking with squid -k parse. Is this OK or would you like me to remove validators?