### PR TITLE
Added support for cache hierarchies and some small changes

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "2.6.0"
   symlinks:
       squid3: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,10 @@ class squid3 (
   $service_enable                = $::squid3::params::service_enable,
   $service_name                  = $::squid3::params::service_name,
   $allow_localnet                = true,
+  $cache_peer                    = [],
+  $cache_peer_access             = [],
+  $always_direct                 = [],
+  $never_direct                  = [],
 ) inherits ::squid3::params {
 
   $use_template = $template ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class squid3 (
   $service_ensure                = 'running',
   $service_enable                = $::squid3::params::service_enable,
   $service_name                  = $::squid3::params::service_name,
+  $allow_localnet                = true,
 ) inherits ::squid3::params {
 
   $use_template = $template ? {

--- a/spec/classes/squid3_spec.rb
+++ b/spec/classes/squid3_spec.rb
@@ -139,4 +139,26 @@ describe 'squid3' do
       end
     end
 
+    context 'RedHat - disable allow localnet' do
+        let(:facts) { facts_hash }
+        let(:params){{
+          :template       => 'short',
+          :allow_localnet => false,
+        }}
+
+        it "config file should not contain \"http_access allow localnet\"" do
+          should_not contain_file('/etc/squid/squid.conf').with_content( /http_access +allow +localnet/ )
+        end
+    end
+
+    context 'RedHat - localnet should be allowed with default opts.' do
+        let(:facts) { facts_hash }
+        let(:params){{
+          :template       => 'short',
+        }}
+
+        it "config file should contain \"http_access allow localnet\"" do
+          should contain_file('/etc/squid/squid.conf').with_content( /http_access +allow +localnet/ )
+        end
+    end
 end

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -4631,7 +4631,7 @@ always_direct <%= line %>
 # none
 <% if !@never_direct.empty? -%>
 # user-defined never_direct
-<% @never_direct.each do |line| -%> 
+<% @never_direct.each do |line| -%>
 never_direct <%= line %>
 <% end -%>
 <% end -%>

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1798,7 +1798,7 @@ tcp_outgoing_address <%= line %>
 #	
 #Default:
 # none
-<% if @cache_peer -%>
+<% if !@cache_peer.empty? -%>
 # user-defined cache_peer
 <% @cache_peer.each do |line| -%>
 cache_peer <%= line %>
@@ -1845,7 +1845,7 @@ cache_peer <%= line %>
 #	the Squid FAQ (http://wiki.squid-cache.org/SquidFaq/SquidAcl).
 #Default:
 # none
-<% if @cache_peer_access -%>
+<% if !@cache_peer_access.empty? -%>
 # user-defined cache_peer_access
 <% @cache_peer_access.each do |line| -%>
 cache_peer_access <%= line %>
@@ -4594,7 +4594,7 @@ server_persistent_connections <%= @server_persistent_connections %>
 #	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 #Default:
 # none
-<% if @always_direct -%>
+<% if !@always_direct.empty? -%>
 # user-defined always_direct
 <% @always_direct.each do |line| -%>
 always_direct <%= line %>
@@ -4629,7 +4629,7 @@ always_direct <%= line %>
 #	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 #Default:
 # none
-<% if @never_direct -%>
+<% if !@never_direct.empty? -%>
 # user-defined never_direct
 <% @never_direct.each do |line| -%> 
 never_direct <%= line %>

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -786,7 +786,9 @@ http_access <%= line %>
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
+<% if @allow_localnet -%>
 http_access allow localnet
+<% end -%>
 http_access allow localhost
 
 # And finally deny all other access to this proxy

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1798,6 +1798,12 @@ tcp_outgoing_address <%= line %>
 #	
 #Default:
 # none
+<% if @cache_peer -%>
+# user-defined cache_peer
+<% @cache_peer.each do |line| -%>
+cache_peer <%= line %>
+<% end -%>
+<% end -%>
 
 #  TAG: cache_peer_domain
 #	Use to limit the domains for which a neighbor cache will be
@@ -1839,6 +1845,12 @@ tcp_outgoing_address <%= line %>
 #	the Squid FAQ (http://wiki.squid-cache.org/SquidFaq/SquidAcl).
 #Default:
 # none
+<% if @cache_peer_access -%>
+# user-defined cache_peer_access
+<% @cache_peer_access.each do |line| -%>
+cache_peer_access <%= line %>
+<% end -%>
+<% end -%>
 
 #  TAG: neighbor_type_domain
 #	usage: neighbor_type_domain neighbor parent|sibling domain domain ...
@@ -4582,6 +4594,12 @@ server_persistent_connections <%= @server_persistent_connections %>
 #	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 #Default:
 # none
+<% if @always_direct -%>
+# user-defined always_direct
+<% @always_direct.each do |line| -%>
+always_direct <%= line %>
+<% end -%>
+<% end -%>
 
 #  TAG: never_direct
 #	Usage: never_direct allow|deny [!]aclname ...
@@ -4611,6 +4629,12 @@ server_persistent_connections <%= @server_persistent_connections %>
 #	See http://wiki.squid-cache.org/SquidFaq/SquidAcl for details.
 #Default:
 # none
+<% if @never_direct -%>
+# user-defined never_direct
+<% @never_direct.each do |line| -%> 
+never_direct <%= line %>
+<% end -%>
+<% end -%>
 
 # ADVANCED NETWORKING OPTIONS
 # -----------------------------------------------------------------------------

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -70,20 +70,20 @@ tcp_outgoing_address <%= line %>
 cache_dir <%= line %>
 <% end -%>
 
-<% if @cache_peer -%>
+<% if !@cache_peer.empty? -%>
 # user-defined cache_peer
 <% @cache_peer.each do |line| -%>
 cache_peer <%= line %>
 <% end -%>
-<% end -%>
 
-<% if @cache_peer_access -%>
+<% end -%>
+<% if !@cache_peer_access.empty? -%>
 # user-defined cache_peer_access
 <% @cache_peer_access.each do |line| -%>
 cache_peer_access <%= line %>
 <% end -%>
-<% end -%>
 
+<% end -%>
 # general settings
 hierarchy_stoplist             cgi-bin ?
 coredump_dir                   <%= @coredump_dir %>
@@ -116,20 +116,20 @@ refresh_pattern                ^gopher:           1440     0%     1440
 refresh_pattern                -i (/cgi-bin/|\?)     0     0%        0
 refresh_pattern                .                     0    20%     4320
 
-<% if @always_direct -%>
+<% if !@always_direct.empty? -%>
 # user-defined always_direct
 <% @always_direct.each do |line| -%> 
 always_direct <%= line %>
 <% end -%>
-<% end -%>
 
-<% if @never_direct -%>
+<% end -%>
+<% if !@never_direct.empty? -%>
 # user-defined never_direct
 <% @never_direct.each do |line| -%> 
 never_direct <%= line %>
 <% end -%>
-<% end -%>
 
+<% end -%>
 # user-defined configuration settings from config_hash
 <% @config_hash.sort_by {|k,v| k}.each do |k,v| -%>
 <%= "%*s"%[-30,k] %> <%= v %>

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -74,7 +74,9 @@ hierarchy_stoplist             cgi-bin ?
 coredump_dir                   <%= @coredump_dir %>
 maximum_object_size_in_memory  <%= @maximum_object_size_in_memory  %>
 maximum_object_size            <%= @maximum_object_size            %>
+<% if @ignore_expect_100 != "off" -%>
 ignore_expect_100              <%= @ignore_expect_100              %>
+<% end -%>
 cache_mgr                      <%= @cache_mgr                      %>
 client_persistent_connections  <%= @client_persistent_connections  %>
 server_persistent_connections  <%= @server_persistent_connections  %>

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -35,7 +35,9 @@ acl <%= line %>
 <% @http_access.each do |line| -%>
 http_access <%= line %>
 <% end -%>
+<% if @allow_localnet -%>
 http_access allow localnet
+<% end -%>
 http_access allow localhost
 http_access deny all
 

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -70,6 +70,19 @@ tcp_outgoing_address <%= line %>
 cache_dir <%= line %>
 <% end -%>
 
+<% if @cache_peer -%>
+# user-defined cache_peer
+<% @cache_peer.each do |line| -%>
+cache_peer <%= line %>
+<% end -%>
+<% end -%>
+
+<% if @cache_peer_access -%>
+# user-defined cache_peer_access
+<% @cache_peer_access.each do |line| -%>
+cache_peer_access <%= line %>
+<% end -%>
+<% end -%>
 
 # general settings
 hierarchy_stoplist             cgi-bin ?
@@ -103,6 +116,19 @@ refresh_pattern                ^gopher:           1440     0%     1440
 refresh_pattern                -i (/cgi-bin/|\?)     0     0%        0
 refresh_pattern                .                     0    20%     4320
 
+<% if @always_direct -%>
+# user-defined always_direct
+<% @always_direct.each do |line| -%> 
+always_direct <%= line %>
+<% end -%>
+<% end -%>
+
+<% if @never_direct -%>
+# user-defined never_direct
+<% @never_direct.each do |line| -%> 
+never_direct <%= line %>
+<% end -%>
+<% end -%>
 
 # user-defined configuration settings from config_hash
 <% @config_hash.sort_by {|k,v| k}.each do |k,v| -%>

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -118,14 +118,14 @@ refresh_pattern                .                     0    20%     4320
 
 <% if !@always_direct.empty? -%>
 # user-defined always_direct
-<% @always_direct.each do |line| -%> 
+<% @always_direct.each do |line| -%>
 always_direct <%= line %>
 <% end -%>
 
 <% end -%>
 <% if !@never_direct.empty? -%>
 # user-defined never_direct
-<% @never_direct.each do |line| -%> 
+<% @never_direct.each do |line| -%>
 never_direct <%= line %>
 <% end -%>
 


### PR DESCRIPTION
Hi,

thanks for the module, I added the following features:
- Removed the `ignore_expect_100` directive if it is turned off. So squid 3.3 won't complain about an obsolete directive.
- Added a way to disable the allow rule for localnet, without breaking compatibility for existing users.
- Changed the stdlib url to https, so tests now also work behind proxy servers.
- Added support for cache hierarchies, aka. interacting with other proxy servers.
