### PR TITLE
Added support for a basic authentication scheme : 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,49 @@ class { '::squid3':
   server_persistent_connections => 'off',
 }
 ```
+Non-caching multi-homed proxy server with basic ldap authentication :
+
+```puppet
+class { '::squid3':
+  acl => [
+    'country_de myip 192.168.1.1',
+    'country_fr myip 192.168.1.2',
+    'office src 10.0.0.0/24',
+  ],
+  http_access => [
+    'deny !squidallowed',
+    'allow office',
+  ],
+  cache => [ 'deny all' ],
+  via => 'off',
+  tcp_outgoing_address => [
+    '192.168.1.1 country_de',
+    '192.168.1.2 country_fr',
+  ],
+  server_persistent_connections => 'off',
+  use_auth       => true,
+  auth_type      => 'basic',
+  auth_options   => {
+    children       => 5,
+    realm          => 'Squid proxy-caching web server',
+    credentialsttl => '1 minute',
+    program        => '/usr/lib64/squid/squid_ldap_auth -b "ou=Users,o=Company,DC=com" -D "cn=LdapBindDN,ou=Users,o=Company,DC=com" -w "VerySecretPassword" -f "(&(cn=%s)(objectClass=person))" -h ldaps://ldapserver:636'
+  }
+  auth_ext_acl   => 'UserAllowed ipv4 ttl=1 %LOGIN /usr/lib64/squid/squid_ldap_group -b "ou=Users,o=Company,DC=com" -f "(&(cn=%g)(objectClass=groupOfNames)(member=%u))" -F "(&(cn=%s)(objectClass=person))" -B "ou=Users,o=Company,DC=com" -H ldaps://ldapserver:636 -v 3 -D "cn=LdapBindDN,ou=Users,o=Company,DC=com" -w "VerySecretPassword"'
+  auth_acl       => [
+    'squidallowed external UserAllowed GrpSquidAccess',
+    'ldapauth proxy_auth REQUIRED']
+  allow_localnet => false
+}
+```
+
+to uninstall :
+
+```puppet
+class { '::squid3':
+  package_version => 'absent'
+}
+```
 
 ## Caveats
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,19 @@
+# Class: squid3::config
+#
+class ::squid3::config (
+) inherits ::squid3 {
+  $use_template = $squid3::template ? {
+    'short' => 'squid3/squid.conf.short.erb',
+    'long'  => 'squid3/squid.conf.long.erb',
+    default => $squid3::template,
+  }
+  if ! empty($squid3::config_hash) and $use_template == 'long' {
+    fail('$config_hash does not (yet) work with the "long" template!')
+  }
+  file { $squid3::config_file:
+    require      => Package['squid3_package'],
+    notify       => Service['squid3_service'],
+    content      => template($use_template),
+    validate_cmd => "/usr/sbin/${squid3::service_name} -k parse -f %",
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # Class: squid3::config
 #
-class ::squid3::config (
+class squid3::config (
 ) inherits ::squid3 {
   $use_template = $squid3::template ? {
     'short' => 'squid3/squid.conf.short.erb',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,9 @@
+# Class: squid3::install
+#
+class squid3::install (
+) inherits ::squid3 {
+  package { 'squid3_package':
+    ensure => $squid3::package_version,
+    name   => $squid3::package_name,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,4 +45,10 @@ class squid3::params {
   $cache_log       = "${log_directory}/cache.log"
   $cache_store_log = "${log_directory}/store.log"
 
+  $use_auth        = false
+  $auth_type       = ''
+  $auth_options    = []
+  $auth_ext_acl    = ''
+  $auth_acl        = []
+  $allow_localnet  = true
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,14 @@
+# Class: squid3::service
+#
+class squid3::service (
+) inherits ::squid3 {
+  service { 'squid3_service':
+    ensure    => $squid3::service_ensure,
+    enable    => $squid3::service_enable,
+    name      => $squid3::service_name,
+    restart   => "service ${squid3::service_name} reload",
+    path      => [ '/sbin', '/usr/sbin', '/usr/local/etc/rc.d' ],
+    hasstatus => true,
+    require   => Package['squid3_package'],
+  }
+}

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -294,6 +294,10 @@
 ##auth_param basic credentialsttl 2 hours
 #Default:
 # none
+<% if @use_auth -%>
+<% @auth_options.keys.sort.each do |option| -%>
+auth_param <%= @auth_type -%> <%= option -%> <%= @auth_options[option] %>
+<% end -%>
 
 #  TAG: authenticate_cache_garbage_interval
 #	The time period between garbage collection across the username cache.
@@ -424,6 +428,10 @@
 #	The query channel tag is a number between 0 and concurrency-1.
 #Default:
 # none
+<% @auth_ext_acl.each do |eacl| -%>
+external_acl_type <%= eacl %>
+<% end -%>
+<% end -%>
 
 #  TAG: acl
 #	Defining an Access List
@@ -786,7 +794,9 @@ http_access <%= line %>
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
+<% if @allow_localnet -%>
 http_access allow localnet
+<% end -%>
 http_access allow localhost
 
 # And finally deny all other access to this proxy

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -1,17 +1,26 @@
 ## THIS FILE IS MANAGED BY PUPPET.
 ## DO NOT EDIT.
 
+<% if @use_auth -%>
+# Authentication 
+<% @auth_options.keys.sort.each do |option| -%>
+auth_param <%= @auth_type -%> <%= option -%> <%= @auth_options[option] %>
+<% end -%>
+<% @auth_ext_acl.each do |eacl| -%>
+external_acl_type <%= eacl %>
+<% end -%>
+<% end -%>
 # predefined ACLs
 <% if @use_deprecated_opts -%>
 acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
 <% end -%>
-acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
-acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
-acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
-acl localnet src fc00::/7       # RFC 4193 local private network range
-acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+acl localnet src 10.0.0.0/8 # RFC1918 possible internal network
+acl localnet src 172.16.0.0/12 # RFC1918 possible internal network
+acl localnet src 192.168.0.0/16 # RFC1918 possible internal network
+acl localnet src fc00::/7 # RFC 4193 local private network range
+acl localnet src fe80::/10 # RFC 4291 link-local (directly plugged) machines
 <% @ssl_ports.each do |line| -%>
 acl SSL_ports port <%= line %>
 <% end -%>
@@ -31,11 +40,18 @@ http_access deny CONNECT !SSL_ports
 acl <%= line %>
 <% end -%>
 
+<% @auth_acl.each do |aacl| -%>
+acl <%= aacl %>
+<% end -%>
+
+
 # user-defined http_accesses
 <% @http_access.each do |line| -%>
 http_access <%= line %>
 <% end -%>
+<% if @allow_localnet -%>
 http_access allow localnet
+<% end -%>
 http_access allow localhost
 http_access deny all
 


### PR DESCRIPTION
- added the followings params to init/params
  - use_auth     => Boolean
  - auth_type    => String : the squid auth type (basic...)
  - auth_options => Hash : the corresponding options to the auth_type
  - auth_ext_acl => String : If any, the external acl used for the authentication
  - auth_acl     => Array : The [ldap] authentication ACL
- Reorganized the manifests into classes for easier update
- Updates the two templates for make it work with the auth. options
- Updated the README.md to illustrate the changes
