### PR TITLE
update validate path to work on all operating systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,11 +57,16 @@ class squid3 (
     require   => Package['squid3_package'],
   }
 
+  case $::osfamily {
+    'FreeBSD': { $cmdpath = "/usr/local/sbin" }
+    default: { $cmdpath = "/usr/sbin" }
+  }
+
   file { $config_file:
     require      => Package['squid3_package'],
     notify       => Service['squid3_service'],
     content      => template($use_template),
-    validate_cmd => "/usr/sbin/${service_name} -k parse -f %",
+    validate_cmd => "${cmdpath}/${service_name} -k parse -f %",
   }
 
 }


### PR DESCRIPTION
the config_file validation was failing because it used the full path for squid, but that path is not the path on freebsd.  this change updates the path for freebsd but doesn't change it for any other OS.