### PR TITLE
Add option to remove localnet defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 class squid3 (
   # Options are in the same order they appear in squid.conf
   $use_deprecated_opts           = true,
+  $use_default_localnet          = true,
   $http_port                     = [ '3128' ],
   $https_port                    = [],
   $acl                           = [],

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -648,11 +648,13 @@ acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing
 # should be allowed
+<% if @use_default_localnet -%>
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl localnet src fc00::/7       # RFC 4193 local private network range
 acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+<% end -%>
 
 <% @ssl_ports.each do |line| -%>
 acl SSL_ports port <%= line %>
@@ -786,7 +788,9 @@ http_access <%= line %>
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
+<% if @use_default_localnet -%>
 http_access allow localnet
+<% end -%>
 http_access allow localhost
 
 # And finally deny all other access to this proxy

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -7,11 +7,13 @@ acl manager proto cache_object
 acl localhost src 127.0.0.1/32 ::1
 acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
 <% end -%>
+<% if @use_default_localnet -%>
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl localnet src fc00::/7       # RFC 4193 local private network range
 acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+<% end -%>
 <% @ssl_ports.each do |line| -%>
 acl SSL_ports port <%= line %>
 <% end -%>
@@ -35,7 +37,9 @@ acl <%= line %>
 <% @http_access.each do |line| -%>
 http_access <%= line %>
 <% end -%>
+<% if @use_default_localnet -%>
 http_access allow localnet
+<% end -%>
 http_access allow localhost
 http_access deny all
 


### PR DESCRIPTION
if set to false, the option removes the default localnet acl definitions
and the default localnet http_access to allow a custom localnet
configuration