### PR TITLE
Adding support for icp_port in init and templates.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@ class squid3 (
   $cache_mem                     = '256 MB',
   $cache_dir                     = [],
   $cache                         = [],
+  $cache_peer                    = [],
+  $cache_peer_access             = [],
   $via                           = 'on',
   $ignore_expect_100             = 'off',
   $cache_mgr                     = 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class squid3 (
   $safe_ports                    = [ '80', '21', '443', '70', '210', '1025-65535', '280', '488', '591', '777', ],
   $http_access                   = [],
   $icp_access                    = [],
+  $icp_port                      = [],
   $tcp_outgoing_address          = [],
   $cache_mem                     = '256 MB',
   $cache_dir                     = [],

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -4149,6 +4149,12 @@ server_persistent_connections <%= @server_persistent_connections %>
 #		icp_port 3130
 #Default:
 # icp_port 0
+<% if @icp_port -%>
+# user-defined icp_port
+<% @icp_port.each do |line| -%>
+icp_port <%= line %>
+<% end -%>
+<% end -%>
 
 #  TAG: htcp_port
 #	The port number where Squid sends and receives HTCP queries to

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1189,6 +1189,20 @@ https_port <%= line %>
 <% end -%>
 <% end -%>
 
+<% if @cache_peer -%>
+# user-defined cache_peer
+<% @cache_peer.each do |line| -%>
+cache_peer <%= line %>
+<% end -%>
+<% end -%>
+
+<% if @cache_peer_access -%>
+# user-defined cache_peer_access
+<% @cache_peer_access.each do |line| -%>
+cache_peer_access <%= line %>
+<% end -%>
+<% end -%>
+
 #  TAG: tcp_outgoing_tos
 #	Allows you to select a TOS/Diffserv value to mark outgoing
 #	connections with, based on the username or source address

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -58,6 +58,20 @@ https_port <%= line %>
 <% end -%>
 <% end -%>
 
+<% if @cache_peer -%>
+# user-defined cache_peer
+<% @cache_peer.each do |line| -%>
+cache_peer <%= line %>
+<% end -%>
+<% end -%>
+
+<% if @cache_peer_access -%>
+# user-defined cache_peer_access
+<% @cache_peer_access.each do |line| -%>
+cache_peer_access <%= line %>
+<% end -%>
+<% end -%>
+
 # user-defined tcp_outgoing_addresses
 <% @tcp_outgoing_address.each do |line| -%>
 tcp_outgoing_address <%= line %>

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -44,6 +44,13 @@ http_access deny all
 icp_access <%= line %>
 <% end -%>
 
+<% if @icp_port -%>
+# user-defined icp_port
+<% @icp_port.each do |line| -%>
+icp_port <%= line %>
+<% end -%>
+<% end -%>
+
 <% if @http_port -%>
 # user-defined http_port
 <% @http_port.each do |line| -%>


### PR DESCRIPTION
It is necessary to declare icp_port in addition to icp_access.
