### PR TITLE
we shouldn't allow 'http_access allow localnet' by default.  if neede…

### DIFF
--- a/templates/squid.conf.documented
+++ b/templates/squid.conf.documented
@@ -783,7 +783,6 @@ http_access deny CONNECT !SSL_ports
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
-http_access allow localnet
 http_access allow localhost
 
 # And finally deny all other access to this proxy

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -786,7 +786,6 @@ http_access <%= line %>
 # Example rule allowing access from your local networks.
 # Adapt localnet in the ACL section to list your (internal) IP networks
 # from where browsing should be allowed
-http_access allow localnet
 http_access allow localhost
 
 # And finally deny all other access to this proxy

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -35,7 +35,6 @@ acl <%= line %>
 <% @http_access.each do |line| -%>
 http_access <%= line %>
 <% end -%>
-http_access allow localnet
 http_access allow localhost
 http_access deny all
 


### PR DESCRIPTION
…d, it should be added manually.  closes #17'