### PR TITLE
Added support for Ubuntu 16

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,12 +16,21 @@ class squid3::params {
       $coredump_dir   = '/var/spool/squid'
     }
     'Debian', 'Ubuntu': {
-      $package_name   = 'squid3'
-      $service_name   = 'squid3'
-      $service_enable = false
-      $config_file    = '/etc/squid3/squid.conf'
-      $log_directory  = '/var/log/squid3'
-      $coredump_dir   = '/var/spool/squid3'
+      if versioncmp($::operatingsystemrelease,'16') > 0 {
+        $package_name   = 'squid'
+        $service_name   = 'squid'
+        $service_enable = false
+        $config_file    = '/etc/squid/squid.conf'
+        $log_directory  = '/var/log/squid'
+        $coredump_dir   = '/var/spool/squid'
+      } else {
+        $package_name   = 'squid3'
+        $service_name   = 'squid3'
+        $service_enable = false
+        $config_file    = '/etc/squid3/squid.conf'
+        $log_directory  = '/var/log/squid3'
+        $coredump_dir   = '/var/spool/squid3'
+      }
     }
     default: {
       $package_name   = 'squid'


### PR DESCRIPTION
Ubuntu 16.04 is installing Squid in `/etc/squid/` not `/etc/squid3/`