### PR TITLE
Fix log access on EL6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,8 +50,8 @@ class squid3::params {
     }
   }
 
-  $access_log      = [ "stdio:${log_directory}/access.log squid" ]
+  $access_log      = [ "${log_directory}/access.log squid" ]
   $cache_log       = "${log_directory}/cache.log"
-  $cache_store_log = "stdio:${log_directory}/store.log"
+  $cache_store_log = "${log_directory}/store.log"
 
 }


### PR DESCRIPTION
The 'stdio' in front of the log access leads to errors starting squid
on EL6:

Cannot open 'stdio:/var/log/squid/store.log' because#012#011the
parent directory does not exist.#012#011Please create the directory.
