### PR TITLE
Remove hierarchy_stoplist

### DIFF
--- a/templates/squid.conf.documented
+++ b/templates/squid.conf.documented
@@ -1863,17 +1863,6 @@ http_port 3128
 #Default:
 # forward_max_tries 10
 
-#  TAG: hierarchy_stoplist
-#	A list of words which, if found in a URL, cause the object to
-#	be handled directly by this cache.  In other words, use this
-#	to not query neighbor caches for certain objects.  You may
-#	list this option multiple times.
-#	Note: never_direct overrides this option.
-#
-
-# We recommend you to use at least the following line.
-hierarchy_stoplist cgi-bin ?
-
 # MEMORY CACHE OPTIONS
 # -----------------------------------------------------------------------------
 

--- a/templates/squid.conf.long.erb
+++ b/templates/squid.conf.long.erb
@@ -1883,17 +1883,6 @@ tcp_outgoing_address <%= line %>
 #Default:
 # forward_max_tries 10
 
-#  TAG: hierarchy_stoplist
-#	A list of words which, if found in a URL, cause the object to
-#	be handled directly by this cache.  In other words, use this
-#	to not query neighbor caches for certain objects.  You may
-#	list this option multiple times.
-#	Note: never_direct overrides this option.
-#
-
-# We recommend you to use at least the following line.
-hierarchy_stoplist cgi-bin ?
-
 # MEMORY CACHE OPTIONS
 # -----------------------------------------------------------------------------
 

--- a/templates/squid.conf.short.erb
+++ b/templates/squid.conf.short.erb
@@ -69,7 +69,6 @@ tcp_outgoing_address <%= line %>
 
 
 # general settings
-hierarchy_stoplist             cgi-bin ?
 coredump_dir                   <%= @coredump_dir %>
 maximum_object_size_in_memory  <%= @maximum_object_size_in_memory  %>
 maximum_object_size            <%= @maximum_object_size            %>


### PR DESCRIPTION
according to http://www.squid-cache.org/mail-archive/squid-users/201210/0027.html its not needed in any squid3 configuration file and its not available in current squid releases